### PR TITLE
Loop over cameras (not lidar sweeps) when rendering

### DIFF
--- a/argoverse/data_loading/simple_track_dataloader.py
+++ b/argoverse/data_loading/simple_track_dataloader.py
@@ -92,6 +92,12 @@ class SimpleArgoverseTrackingDataLoader:
 
     def get_closest_lidar_fpath(self, log_id: str, cam_timestamp: int) -> Optional[str]:
         """
+        Args:
+            log_id: str, unique ID of vehicle log
+            cam_timestamp: int, timestamp of image capture, in nanoseconds
+
+        Returns:
+            ply_fpath: str, string representing path to PLY file, or else None.
         """
         lidar_timestamp = self.sdb.get_closest_lidar_timestamp(cam_timestamp, log_id)
         if lidar_timestamp is None:
@@ -114,8 +120,11 @@ class SimpleArgoverseTrackingDataLoader:
     def get_ordered_log_cam_fpaths(self, log_id: str, camera_name: str) -> List[str]:
         """
         Args
+            log_id: str, unique ID of vehicle log
 
         Returns
+            cam_img_fpaths: List of strings, representing paths to JPEG files in this log,
+                for a specific camera
         """
         cam_img_fpaths = sorted(glob.glob(f"{self.data_dir}/{log_id}/{camera_name}/{camera_name}_*.jpg"))
         return cam_img_fpaths

--- a/argoverse/data_loading/simple_track_dataloader.py
+++ b/argoverse/data_loading/simple_track_dataloader.py
@@ -54,16 +54,16 @@ class SimpleArgoverseTrackingDataLoader:
         assert isinstance(log_calib_data, dict)
         return log_calib_data
 
-    def get_city_to_egovehicle_se3(self, log_id: str, lidar_timestamp: int) -> Optional[SE3]:
+    def get_city_to_egovehicle_se3(self, log_id: str, timestamp: int) -> Optional[SE3]:
         """
         Args:
             log_id: str, unique ID of vehicle log
-            lidar_timestamp: int, timestamp of LiDAR sweep capture, in nanoseconds
+            timestamp: int, timestamp of sensor observation, in nanoseconds
 
         Returns:
             city_to_egovehicle_se3: SE3 transformation to bring egovehicle frame point into city frame.
         """
-        pose_fpath = f"{self.data_dir}/{log_id}/poses/city_SE3_egovehicle_{lidar_timestamp}.json"
+        pose_fpath = f"{self.data_dir}/{log_id}/poses/city_SE3_egovehicle_{timestamp}.json"
         if not Path(pose_fpath).exists():
             return None
         pose_data = read_json_file(pose_fpath)
@@ -90,6 +90,17 @@ class SimpleArgoverseTrackingDataLoader:
         im_fpath = f"{im_dir}/{im_fname}"
         return im_fpath
 
+    def get_closest_lidar_fpath(self, log_id: str, cam_timestamp: int) -> Optional[str]:
+        """
+        """
+        lidar_timestamp = self.sdb.get_closest_lidar_timestamp(cam_timestamp, log_id)
+        if lidar_timestamp is None:
+            return None
+        lidar_dir = f"{self.data_dir}/{log_id}/lidar"
+        ply_fname = f"PC_{lidar_timestamp}.ply"
+        ply_fpath = f"{lidar_dir}/{ply_fname}"
+        return ply_fpath
+
     def get_ordered_log_ply_fpaths(self, log_id: str) -> List[str]:
         """
         Args:
@@ -99,6 +110,15 @@ class SimpleArgoverseTrackingDataLoader:
             """
         ply_fpaths = sorted(glob.glob(f"{self.data_dir}/{log_id}/lidar/PC_*.ply"))
         return ply_fpaths
+
+    def get_ordered_log_cam_fpaths(self, log_id: str, camera_name: str) -> List[str]:
+        """
+        Args
+
+        Returns
+        """
+        cam_img_fpaths = sorted(glob.glob(f"{self.data_dir}/{log_id}/{camera_name}/{camera_name}_*.jpg"))
+        return cam_img_fpaths
 
     def get_labels_at_lidar_timestamp(self, log_id: str, lidar_timestamp: int) -> Optional[List[Mapping[str, Any]]]:
         """

--- a/argoverse/data_loading/synchronization_database.py
+++ b/argoverse/data_loading/synchronization_database.py
@@ -154,7 +154,7 @@ class SynchronizationDB:
 
         cam_timestamps = self.per_log_camtimestamps_index[log_id][camera_name]
         # catch case if no files were loaded for a particular sensor
-        if not timestamps.tolist():
+        if not cam_timestamps.tolist():
             return None
 
         closest_cam_ch_timestamp, timestamp_diff = find_closest_integer_in_ref_arr(lidar_timestamp, cam_timestamps)

--- a/argoverse/data_loading/synchronization_database.py
+++ b/argoverse/data_loading/synchronization_database.py
@@ -4,10 +4,10 @@
 
 import glob
 import logging
-import pdb
 from typing import Dict, Iterable, List, Optional, Tuple, cast
 
 import numpy as np
+
 from argoverse.utils.camera_stats import RING_CAMERA_LIST, STEREO_CAMERA_LIST
 from argoverse.utils.json_utils import read_json_file
 
@@ -31,7 +31,7 @@ def get_timestamps_from_sensor_folder(sensor_folder_wildcard: str) -> np.ndarray
     return np.array([int(jpg_fpath.split("/")[-1].split(".")[0].split("_")[-1]) for jpg_fpath in path_generator])
 
 
-def find_closest_integer_in_ref_arr(query_int: int, ref_arr: np.ndarray) -> Tuple[int,int]:
+def find_closest_integer_in_ref_arr(query_int: int, ref_arr: np.ndarray) -> Tuple[int, int]:
     """
     Find the closest integer to any integer inside a reference array, and the corresponding
     difference.
@@ -53,8 +53,6 @@ def find_closest_integer_in_ref_arr(query_int: int, ref_arr: np.ndarray) -> Tupl
     return closest_int, int_diff
 
 
-
-
 class SynchronizationDB:
 
     # Camera is 30 Hz (once per 33.3 milliseconds)
@@ -66,12 +64,11 @@ class SynchronizationDB:
     # LiDAR is 10 Hz
     # Since Stereo is more sparse, we look for 200 millisecond on either side
     # then convert milliseconds to nanoseconds
-    MAX_LIDAR_STEREO_CAM_TIMESTAMP_DIFF = 200 * (1.0/ 2) * (1.0 / 1000) * 1e9
+    MAX_LIDAR_STEREO_CAM_TIMESTAMP_DIFF = 200 * (1.0 / 2) * (1.0 / 1000) * 1e9
     # LiDAR is 10 Hz (once per 100 milliseconds)
     # At any point we sample, we shouldn't be more than 50 ms away.
     # then convert milliseconds to nanoseconds
-    MAX_LIDAR_ANYCAM_TIMESTAMP_DIFF = 100 * (1.0/ 2) * (1.0 / 1000) * 1e9
-
+    MAX_LIDAR_ANYCAM_TIMESTAMP_DIFF = 100 * (1.0 / 2) * (1.0 / 1000) * 1e9
 
     def __init__(self, dataset_dir: str, collect_single_log_id: Optional[str] = None) -> None:
         """ Build the SynchronizationDB.
@@ -129,7 +126,9 @@ class SynchronizationDB:
         if timestamp_diff > self.MAX_LIDAR_ANYCAM_TIMESTAMP_DIFF:
             # convert to nanoseconds->milliseconds for readability
             logger.error(
-                "No corresponding LiDAR sweep: %s > %s ms", timestamp_diff / 1e6, self.MAX_LIDAR_ANYCAM_TIMESTAMP_DIFF / 1e6
+                "No corresponding LiDAR sweep: %s > %s ms",
+                timestamp_diff / 1e6,
+                self.MAX_LIDAR_ANYCAM_TIMESTAMP_DIFF / 1e6,
             )
             return None
         return closest_lidar_timestamp
@@ -149,7 +148,10 @@ class SynchronizationDB:
             Returns:
                 closest_cam_ch_timestamp: closest timestamp
         """
-        if log_id not in self.per_log_camtimestamps_index or camera_name not in self.per_log_camtimestamps_index[log_id]:
+        if (
+            log_id not in self.per_log_camtimestamps_index
+            or camera_name not in self.per_log_camtimestamps_index[log_id]
+        ):
             return None
 
         cam_timestamps = self.per_log_camtimestamps_index[log_id][camera_name]

--- a/argoverse/data_loading/synchronization_database.py
+++ b/argoverse/data_loading/synchronization_database.py
@@ -34,11 +34,14 @@ def get_timestamps_from_sensor_folder(sensor_folder_wildcard: str) -> np.ndarray
 
 def find_closest_integer_in_ref_arr(query_int: int, ref_arr: np.ndarray) -> Tuple[int, int]:
     """
-    Find the closest integer to any integer inside a reference array, and the corresponding
-    difference.
+        Find the closest integer to any integer inside a reference array, and the corresponding
+        difference.
 
-    In our use case, the query integer represents a nanosecond-discretized timestamp, and the
-    reference array represents a numpy array of nanosecond-discretized timestamps.
+        In our use case, the query integer represents a nanosecond-discretized timestamp, and the
+        reference array represents a numpy array of nanosecond-discretized timestamps.
+
+        Instead of sorting the whole array of timestamp differences, we just
+        take the minimum value (to speed up this function).
 
         Args:
             query_int: query integer, 
@@ -114,7 +117,15 @@ class SynchronizationDB:
         return self.per_log_camtimestamps_index.keys()
 
     def get_closest_lidar_timestamp(self, cam_timestamp: int, log_id: str) -> Optional[int]:
-        """
+        """ Given an image timestamp, find the synchronized corresponding LiDAR timestamp.
+            This LiDAR timestamp should have the closest absolute timestamp to the image timestamp.
+
+            Args:
+                cam_timestamp: integer
+                log_id: string
+
+            Returns:
+                closest_lidar_timestamp: closest timestamp
         """
         if log_id not in self.per_log_lidartimestamps_index:
             return None
@@ -136,11 +147,8 @@ class SynchronizationDB:
         return closest_lidar_timestamp
 
     def get_closest_cam_channel_timestamp(self, lidar_timestamp: int, camera_name: str, log_id: str) -> Optional[int]:
-        """ Grab the LiDAR pose file. Get its timestamp, and then find the pose message
-            with the closest absolute timestamp.
-
-            Instead of sorting the whole array of timestamp differences, we just
-            take the minimum value (to speed up this function).
+        """ Given a LiDAR timestamp, find the synchronized corresponding image timestamp for a particular camera.
+            This image timestamp should have the closest absolute timestamp.
 
             Args:
                 lidar_timestamp: integer

--- a/argoverse/data_loading/synchronization_database.py
+++ b/argoverse/data_loading/synchronization_database.py
@@ -66,9 +66,10 @@ class SynchronizationDB:
     # then convert milliseconds to nanoseconds
     MAX_LIDAR_STEREO_CAM_TIMESTAMP_DIFF = 200 * (1.0 / 2) * (1.0 / 1000) * 1e9
     # LiDAR is 10 Hz (once per 100 milliseconds)
-    # At any point we sample, we shouldn't be more than 50 ms away.
+    # We give an extra 2 ms buffer for the message to arrive, totaling 102 ms.
+    # At any point we sample, we shouldn't be more than 51 ms away.
     # then convert milliseconds to nanoseconds
-    MAX_LIDAR_ANYCAM_TIMESTAMP_DIFF = 100 * (1.0 / 2) * (1.0 / 1000) * 1e9
+    MAX_LIDAR_ANYCAM_TIMESTAMP_DIFF = 102 * (1.0 / 2) * (1.0 / 1000) * 1e9
 
     def __init__(self, dataset_dir: str, collect_single_log_id: Optional[str] = None) -> None:
         """ Build the SynchronizationDB.

--- a/argoverse/data_loading/synchronization_database.py
+++ b/argoverse/data_loading/synchronization_database.py
@@ -4,6 +4,7 @@
 
 import glob
 import logging
+from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple, cast
 
 import numpy as np
@@ -28,7 +29,7 @@ def get_timestamps_from_sensor_folder(sensor_folder_wildcard: str) -> np.ndarray
     path_generator = glob.glob(sensor_folder_wildcard)
     path_generator.sort()
 
-    return np.array([int(jpg_fpath.split("/")[-1].split(".")[0].split("_")[-1]) for jpg_fpath in path_generator])
+    return np.array([int(Path(jpg_fpath).stem.split("_")[-1]) for jpg_fpath in path_generator])
 
 
 def find_closest_integer_in_ref_arr(query_int: int, ref_arr: np.ndarray) -> Tuple[int, int]:
@@ -93,7 +94,7 @@ class SynchronizationDB:
         self.per_log_lidartimestamps_index: Dict[str, np.ndarray] = {}
 
         for log_fpath in log_fpaths:
-            log_id = log_fpath.split("/")[-1]
+            log_id = Path(log_fpath).name
 
             self.per_log_camtimestamps_index[log_id] = {}
             for camera_name in STEREO_CAMERA_LIST + RING_CAMERA_LIST:

--- a/demo_usage/cuboids_to_bboxes.py
+++ b/demo_usage/cuboids_to_bboxes.py
@@ -239,7 +239,7 @@ if __name__ == "__main__":
         "--log-ids",
         type=str,
         required=True,
-        help="comma seperated list of log ids, each log_id represents a log directory, e.g. found at "
+        help="comma separated list of log ids, each log_id represents a log directory, e.g. found at "
         " {args.dataset-dir}/argoverse-tracking/train/{log_id} or "
         " {args.dataset-dir}/argoverse-tracking/sample/{log_id} or ",
     )

--- a/demo_usage/cuboids_to_bboxes.py
+++ b/demo_usage/cuboids_to_bboxes.py
@@ -95,7 +95,7 @@ def dump_clipped_3d_cuboids_to_images(
     data_dir: str,
     experiment_prefix: str,
     is_shrinkwrap: bool,
-    motion_compensate: bool = False,
+    motion_compensate: bool = True,
 ) -> List[str]:
     """
     We bring the 3D points into each camera coordinate system, and do the clipping there in 3D.
@@ -224,11 +224,9 @@ def dump_clipped_3d_cuboids_to_images(
 def main(args: Any):
     """Run the example."""
     log_ids = [log_id.strip() for log_id in args.log_ids.split(",")]
-
     dump_clipped_3d_cuboids_to_images(
         log_ids, args.max_num_images_to_render * 9, args.dataset_dir, args.experiment_prefix, True
     )
-
 
 if __name__ == "__main__":
     # Parse command line arguments

--- a/demo_usage/cuboids_to_bboxes.py
+++ b/demo_usage/cuboids_to_bboxes.py
@@ -12,6 +12,7 @@ from typing import Any, Iterable, List, Mapping, Sequence, Tuple, Union
 import cv2
 import imageio
 import numpy as np
+
 from argoverse.data_loading.object_label_record import json_label_dict_to_obj_record
 from argoverse.data_loading.simple_track_dataloader import SimpleArgoverseTrackingDataLoader
 from argoverse.map_representation.map_api import ArgoverseMap
@@ -120,7 +121,7 @@ def dump_clipped_3d_cuboids_to_images(
 
         city_name = dl.get_city_name(log_id)
         log_calib_data = dl.get_log_calibration_data(log_id)
-        
+
         flag_done = False
         for cam_idx, camera_name in enumerate(RING_CAMERA_LIST + STEREO_CAMERA_LIST):
             cam_im_fpaths = dl.get_ordered_log_cam_fpaths(log_id, camera_name)
@@ -130,7 +131,7 @@ def dump_clipped_3d_cuboids_to_images(
 
                 cam_timestamp = im_fpath.split("/")[-1].split(".")[0].split("_")[-1]
                 cam_timestamp = int(cam_timestamp)
-            
+
                 # load PLY file path, e.g. 'PC_315978406032859416.ply'
                 ply_fpath = dl.get_closest_lidar_fpath(log_id, cam_timestamp)
                 if ply_fpath is None:
@@ -143,7 +144,7 @@ def dump_clipped_3d_cuboids_to_images(
                         flag_done = True
                         break
                     continue
-                
+
                 city_to_egovehicle_se3 = dl.get_city_to_egovehicle_se3(log_id, cam_timestamp)
                 if city_to_egovehicle_se3 is None:
                     continue
@@ -226,6 +227,7 @@ def main(args: Any):
         log_ids, args.max_num_images_to_render * 9, args.dataset_dir, args.experiment_prefix
     )
 
+
 if __name__ == "__main__":
     # Parse command line arguments
     parser = argparse.ArgumentParser()
@@ -237,8 +239,8 @@ if __name__ == "__main__":
         "--log-ids",
         type=str,
         required=True,
-        help="comma seperated list of log ids, this is the folder name in "\
-        " {args.dataset-dir}/argoverse-tracking/train/{log_id} or "\
+        help="comma seperated list of log ids, each log_id represents a log directory, e.g. found at "
+        " {args.dataset-dir}/argoverse-tracking/train/{log_id} or "
         " {args.dataset-dir}/argoverse-tracking/sample/{log_id} or ",
     )
     parser.add_argument(

--- a/demo_usage/cuboids_to_bboxes.py
+++ b/demo_usage/cuboids_to_bboxes.py
@@ -94,7 +94,6 @@ def dump_clipped_3d_cuboids_to_images(
     max_num_images_to_render: int,
     data_dir: str,
     experiment_prefix: str,
-    is_shrinkwrap: bool,
     motion_compensate: bool = True,
 ) -> List[str]:
     """
@@ -105,7 +104,6 @@ def dump_clipped_3d_cuboids_to_images(
         max_num_images_to_render: maximum numbers of images to render.
         data_dir: path to dataset with the latest data
         experiment_prefix: Output directory
-        is_shrinkwrap: Whether to place in a `"shrinkwrap"` output directory
         motion_compensate: Whether to motion compensate when projecting
 
     Returns:
@@ -225,7 +223,7 @@ def main(args: Any):
     """Run the example."""
     log_ids = [log_id.strip() for log_id in args.log_ids.split(",")]
     dump_clipped_3d_cuboids_to_images(
-        log_ids, args.max_num_images_to_render * 9, args.dataset_dir, args.experiment_prefix, True
+        log_ids, args.max_num_images_to_render * 9, args.dataset_dir, args.experiment_prefix
     )
 
 if __name__ == "__main__":

--- a/demo_usage/cuboids_to_bboxes.py
+++ b/demo_usage/cuboids_to_bboxes.py
@@ -127,9 +127,9 @@ def dump_clipped_3d_cuboids_to_images(
             cam_im_fpaths = dl.get_ordered_log_cam_fpaths(log_id, camera_name)
             for i, im_fpath in enumerate(cam_im_fpaths):
                 if i % 50 == 0:
-                    logging.info(f"\tOn file {i} of camera {camera_name} of {log_id}")
+                    logging.info("\tOn file %s of camera %s of %s", i, camera_name, log_id)
 
-                cam_timestamp = im_fpath.split("/")[-1].split(".")[0].split("_")[-1]
+                cam_timestamp = Path(im_fpath).stem.split("_")[-1]
                 cam_timestamp = int(cam_timestamp)
 
                 # load PLY file path, e.g. 'PC_315978406032859416.ply'
@@ -149,11 +149,11 @@ def dump_clipped_3d_cuboids_to_images(
                 if city_to_egovehicle_se3 is None:
                     continue
 
-                lidar_timestamp = ply_fpath.split("/")[-1].split(".")[0].split("_")[-1]
+                lidar_timestamp = Path(ply_fpath).stem.split("_")[-1]
                 lidar_timestamp = int(lidar_timestamp)
                 labels = dl.get_labels_at_lidar_timestamp(log_id, lidar_timestamp)
                 if labels is None:
-                    logger.info(f"\tLabels missing at t={lidar_timestamp}")
+                    logging.info("\tLabels missing at t=%s", lidar_timestamp)
                     continue
 
                 # Swap channel order as OpenCV expects it -- BGR not RGB

--- a/demo_usage/visualize_ground_lidar_points.py
+++ b/demo_usage/visualize_ground_lidar_points.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 import numpy as np
+
 from argoverse.data_loading.synchronization_database import SynchronizationDB
 from argoverse.map_representation.map_api import ArgoverseMap
 from argoverse.utils.camera_stats import CAMERA_LIST
@@ -81,7 +82,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--log-ids",
         type=str,
-        help="Comma seperated list of log ids, this is the folder name in argoverse-tracking/*/[log_id]",
+        help="Comma separated list of log ids, this is the directory name, i.e. as found in {args.dataset-dir}/argoverse-tracking/sample/[log_id]",
     )
     parser.add_argument(
         "--experiment-prefix",

--- a/tests/test_argoverse_tracking_loader.py
+++ b/tests/test_argoverse_tracking_loader.py
@@ -126,6 +126,6 @@ def test_pose(data_loader: ArgoverseTrackingLoader) -> None:
         )
 
 
-def test_idx_from_tiemstamp(data_loader: ArgoverseTrackingLoader) -> None:
+def test_idx_from_timestamp(data_loader: ArgoverseTrackingLoader) -> None:
     for i in range(len(data_loader.lidar_list)):
         assert data_loader.get_idx_from_timestamp(i) == i

--- a/tests/test_simple_track_dataloader.py
+++ b/tests/test_simple_track_dataloader.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 
 import pytest
+
 from argoverse.data_loading.simple_track_dataloader import SimpleArgoverseTrackingDataLoader
 
 _TEST_DATA = pathlib.Path(__file__).parent / "test_data" / "tracking"
@@ -31,7 +32,7 @@ def test_get_city_to_egovehicle_se3(data_loader: SimpleArgoverseTrackingDataLoad
 
 def test_get_closest_im_fpath(data_loader: SimpleArgoverseTrackingDataLoader) -> None:
     # Test data doesn't have cameras so we cannot currently test this if we
-    assert data_loader.get_closest_im_fpath(_LOG_ID, "camera_name", 0) is None
+    assert data_loader.get_closest_im_fpath(_LOG_ID, "nonexisting_camera_name", 0) is None
 
 
 def test_get_ordered_log_ply_fpaths(data_loader: SimpleArgoverseTrackingDataLoader) -> None:
@@ -42,3 +43,44 @@ def test_get_ordered_log_ply_fpaths(data_loader: SimpleArgoverseTrackingDataLoad
 def test_get_labels_at_lidar_timestamp(data_loader: SimpleArgoverseTrackingDataLoader) -> None:
     assert data_loader.get_labels_at_lidar_timestamp(_LOG_ID, 0) is not None
     assert data_loader.get_labels_at_lidar_timestamp(_LOG_ID, 100) is None
+
+
+def test_get_closest_im_fpath_exists(data_loader: SimpleArgoverseTrackingDataLoader) -> None:
+    # Test data does have ring front cameras at timestamps 0,1,2,3. Compare with ground truth (gt)
+    im_fpath = data_loader.get_closest_im_fpath(_LOG_ID, "ring_front_right", 2)
+    gt_im_fpath = f"test_data/tracking/{_LOG_ID}/ring_front_right/ring_front_right_2.jpg"
+    assert "/".join(im_fpath.split("/")[-5:]) == gt_im_fpath
+
+
+def test_get_closest_lidar_fpath_found_match(data_loader: SimpleArgoverseTrackingDataLoader) -> None:
+    """ Just barely within 51 ms allowed buffer"""
+    cam_timestamp = 50 * 1e6
+    ply_fpath = data_loader.get_closest_lidar_fpath(_LOG_ID, cam_timestamp)
+    gt_ply_fpath = f"test_data/tracking/{_LOG_ID}/lidar/PC_2.ply"
+    assert "/".join(ply_fpath.split("/")[-5:]) == gt_ply_fpath
+
+
+def test_get_closest_lidar_fpath_no_match(data_loader: SimpleArgoverseTrackingDataLoader) -> None:
+    """ LiDAR rotates at 10 Hz (sensor message per 100 ms). Test if camera measurement
+        just barely outside 51 ms allowed buffer. Max LiDAR timestamp in log is 2.
+        51 ms, not 50 ms, is allowed to give time for occasional delay.
+    """
+    max_allowed_interval = ((100 / 2) + 1) * 1e6
+    log_max_lidar_timestamp = 2
+    cam_timestamp = log_max_lidar_timestamp + max_allowed_interval + 1
+    ply_fpath = data_loader.get_closest_lidar_fpath(_LOG_ID, cam_timestamp)
+    assert ply_fpath is None
+
+
+def test_get_ordered_log_cam_fpaths(data_loader: SimpleArgoverseTrackingDataLoader) -> None:
+    """ Make sure all images for one camera in one log are returned in correct order. """
+    camera_name = "ring_rear_right"
+    cam_img_fpaths = data_loader.get_ordered_log_cam_fpaths(_LOG_ID, camera_name)
+    gt_cam_img_fpaths = [
+        f"test_data/tracking/{_LOG_ID}/ring_rear_right/ring_rear_right_0.jpg",
+        f"test_data/tracking/{_LOG_ID}/ring_rear_right/ring_rear_right_1.jpg",
+        f"test_data/tracking/{_LOG_ID}/ring_rear_right/ring_rear_right_2.jpg",
+        f"test_data/tracking/{_LOG_ID}/ring_rear_right/ring_rear_right_3.jpg",
+    ]
+    relative_img_fpaths = ["/".join(fpath.split("/")[-5:]) for fpath in cam_img_fpaths]
+    assert relative_img_fpaths == gt_cam_img_fpaths

--- a/tests/test_synchronization_database.py
+++ b/tests/test_synchronization_database.py
@@ -1,0 +1,36 @@
+# <Copyright 2019, Argo AI, LLC. Released under the MIT license.>
+""" Test LiDAR / camera timestamp synchronization utilities"""
+
+import numpy as np
+
+from argoverse.data_loading.synchronization_database import find_closest_integer_in_ref_arr
+
+
+def test_find_closest_integer_in_ref_arr_middle():
+    """
+	"""
+    query_int = 4
+    ref_arr = np.array([0, 1, 2, 5, 6, 7], dtype=np.int64)
+    closest_int, int_diff = find_closest_integer_in_ref_arr(query_int, ref_arr)
+    assert closest_int == 5
+    assert int_diff == 1
+
+
+def test_find_closest_integer_in_ref_arr_before():
+    """
+	"""
+    query_int = 0
+    ref_arr = np.array([2, 5, 6, 7], dtype=np.int64)
+    closest_int, int_diff = find_closest_integer_in_ref_arr(query_int, ref_arr)
+    assert closest_int == 2
+    assert int_diff == 2
+
+
+def test_find_closest_integer_in_ref_arr_after():
+    """
+	"""
+    query_int = 9
+    ref_arr = np.array([0, 1, 2, 5, 6, 7], dtype=np.int64)
+    closest_int, int_diff = find_closest_integer_in_ref_arr(query_int, ref_arr)
+    assert closest_int == 7
+    assert int_diff == 2

--- a/tests/test_synchronization_database.py
+++ b/tests/test_synchronization_database.py
@@ -6,8 +6,10 @@ import numpy as np
 from argoverse.data_loading.synchronization_database import find_closest_integer_in_ref_arr
 
 
-def test_find_closest_integer_in_ref_arr_middle():
+def test_find_closest_integer_in_ref_arr_middle() -> None:
     """
+    Verify that given a query integer, we can find the closest entry
+    in an integer array (if lands in middle of array).
 	"""
     query_int = 4
     ref_arr = np.array([0, 1, 2, 5, 6, 7], dtype=np.int64)
@@ -16,8 +18,10 @@ def test_find_closest_integer_in_ref_arr_middle():
     assert int_diff == 1
 
 
-def test_find_closest_integer_in_ref_arr_before():
+def test_find_closest_integer_in_ref_arr_before() -> None:
     """
+    Verify that given a query integer, we can find the closest entry
+    in an integer array (if lands before start of array).
 	"""
     query_int = 0
     ref_arr = np.array([2, 5, 6, 7], dtype=np.int64)
@@ -26,8 +30,10 @@ def test_find_closest_integer_in_ref_arr_before():
     assert int_diff == 2
 
 
-def test_find_closest_integer_in_ref_arr_after():
+def test_find_closest_integer_in_ref_arr_after() -> None:
     """
+    Verify that given a query integer, we can find the closest entry
+    in an integer array (if lands after the end of the array).
 	"""
     query_int = 9
     ref_arr = np.array([0, 1, 2, 5, 6, 7], dtype=np.int64)


### PR DESCRIPTION
Avoid the optical illusion from plotting annotations from different sweeps in the same image. We switch to looping over images, not PLY fpaths. Fixed typo in unit test.

Rendering now is at 30 fps, not 10 fps (see [this link](https://www.youtube.com/watch?v=iOxbLH8Aq9Q&feature=youtu.be) for an example of new functionality provided by this PR.