### PR TITLE
Move forecasting evaluation unit test to integration test

### DIFF
--- a/integration_tests/test_eval_forecasting.py
+++ b/integration_tests/test_eval_forecasting.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_almost_equal
 
 from argoverse.evaluation.eval_forecasting import compute_forecasting_metrics
 
+
 def test_compute_forecasting_metric():
     """Test computation of motion forecasting metrics."""
     # Test Case:


### PR DESCRIPTION
Forecasting evaluation unit test requires map files. The test will fail unless there are all those expected xml/json/npy map files in the root directory. As such, moving this test to integration tests.