### PR TITLE
optimized forecasting dataloader

### DIFF
--- a/argoverse/data_loading/argoverse_forecasting_loader.py
+++ b/argoverse/data_loading/argoverse_forecasting_loader.py
@@ -48,13 +48,7 @@ class ArgoverseForecastingLoader:
         Returns:
             list of track ids in the current sequence
         """
-        if self._track_id_list is None:
-            self._track_id_list = {}
-            for seq in self.seq_list:
-                seq_df = _read_csv(seq)
-                self._track_id_list[str(seq)] = np.unique(seq_df["TRACK_ID"].values).tolist()
-
-        return self._track_id_list[str(self.current_seq)]
+        return np.unique(self.seq_df["TRACK_ID"].values).tolist()
 
     @property
     def city(self) -> str:
@@ -63,13 +57,7 @@ class ArgoverseForecastingLoader:
         Returns:
             city name, i.e., either 'PIT' or 'MIA'
         """
-        if self._city_list is None:
-            self._city_list = {}
-            for seq in self.seq_list:
-                seq_df = _read_csv(seq)
-                self._city_list[str(seq)] = seq_df["CITY_NAME"].values[0]
-
-        return self._city_list[str(self.current_seq)]
+        return self.seq_df["CITY_NAME"].values[0]
 
     @property
     def num_tracks(self) -> int:

--- a/argoverse/data_loading/argoverse_forecasting_loader.py
+++ b/argoverse/data_loading/argoverse_forecasting_loader.py
@@ -31,9 +31,6 @@ class ArgoverseForecastingLoader:
         Args:
             root_dir: Path to the folder having sequence csv files
         """
-        self._track_id_list: Optional[Mapping[str, Sequence[int]]] = None
-        self._city_list: Optional[Mapping[str, str]] = None
-
         self.counter: int = 0
 
         root_dir = Path(root_dir)
@@ -48,7 +45,8 @@ class ArgoverseForecastingLoader:
         Returns:
             list of track ids in the current sequence
         """
-        return np.unique(self.seq_df["TRACK_ID"].values).tolist()
+        _track_id_list: Sequence[int] = np.unique(self.seq_df["TRACK_ID"].values).tolist()
+        return _track_id_list
 
     @property
     def city(self) -> str:
@@ -57,7 +55,8 @@ class ArgoverseForecastingLoader:
         Returns:
             city name, i.e., either 'PIT' or 'MIA'
         """
-        return self.seq_df["CITY_NAME"].values[0]
+        _city: str = self.seq_df["CITY_NAME"].values[0]
+        return _city
 
     @property
     def num_tracks(self) -> int:


### PR DESCRIPTION
`city` and `track_id_list` properties were reading all the csvs when called for the first time. This PR changes them to directly use the current `seq_df`.
![image](https://user-images.githubusercontent.com/11771909/68641271-57c1ff00-04d8-11ea-8855-5fa7d53029e0.png)
