### PR TITLE
add more clear compose function that is alias for right_multiply_with…

### DIFF
--- a/argoverse/utils/se3.py
+++ b/argoverse/utils/se3.py
@@ -61,10 +61,10 @@ class SE3:
         Algebraic representation: chained_se3 = T * right_se3
 
         Args:
-            right_se3: instance of SE3 class
+            right_se3: another instance of SE3 class
 
         Returns:
-            chained_se3: instance of SE3 class
+            chained_se3: new instance of SE3 class
         """
         chained_transform_matrix = self.transform_matrix.dot(right_se3.transform_matrix)
         chained_se3 = SE3(
@@ -79,9 +79,9 @@ class SE3:
         Algebraic representation: chained_se3 = T * right_se3
 
         Args:
-            right_se3: instance of SE3 class
+            right_se3: another instance of SE3 class
 
         Returns:
-            chained_se3: instance of SE3 class
+            chained_se3: new instance of SE3 class
         """
         return self.compose(right_se3)

--- a/argoverse/utils/se3.py
+++ b/argoverse/utils/se3.py
@@ -66,7 +66,7 @@ class SE3:
         Returns:
             chained_se3: new instance of SE3 class
         """
-        chained_transform_matrix = self.transform_matrix.dot(right_se3.transform_matrix)
+        chained_transform_matrix = self.transform_matrix @ right_se3.transform_matrix
         chained_se3 = SE3(
             rotation=chained_transform_matrix[:3, :3],
             translation=chained_transform_matrix[:3, 3],

--- a/argoverse/utils/se3.py
+++ b/argoverse/utils/se3.py
@@ -55,8 +55,8 @@ class SE3:
         """
         return SE3(rotation=self.rotation.T, translation=self.rotation.T.dot(-self.translation))
 
-    def right_multiply_with_se3(self, right_se3: "SE3") -> "SE3":
-        """Right multiply the transformation matrix with another SE3 instance.
+    def compose(self, right_se3: "SE3") -> "SE3":
+        """Compose (right multiply) this class' transformation matrix T with another SE3 instance.
 
         Algebraic representation: chained_se3 = T * right_se3
 
@@ -72,3 +72,17 @@ class SE3:
             translation=chained_transform_matrix[:3, 3],
         )
         return chained_se3
+
+    def right_multiply_with_se3(self, right_se3: "SE3") -> "SE3":
+        """Compose (right multiply) this class' transformation matrix T with another SE3 instance.
+
+        Algebraic representation: chained_se3 = T * right_se3
+
+        Args:
+            right_se3: instance of SE3 class
+
+        Returns:
+            chained_se3: instance of SE3 class
+        """
+        return self.compose(right_se3)
+    

--- a/argoverse/utils/se3.py
+++ b/argoverse/utils/se3.py
@@ -85,4 +85,3 @@ class SE3:
             chained_se3: instance of SE3 class
         """
         return self.compose(right_se3)
-    


### PR DESCRIPTION
Add a `compose()` method to the SE(3) class, which is an alias for `right_multiply_with_se3()` and has a more clear naming convention. In line with [GTSAM's `compose()`](https://github.com/borglab/gtsam/blob/develop/gtsam/geometry/Pose3.h#L111)