### PR TITLE
Adding map_files_root as an argument of ArgoverseMap

### DIFF
--- a/argoverse/map_representation/map_api.py
+++ b/argoverse/map_representation/map_api.py
@@ -54,8 +54,14 @@ class ArgoverseMap:
     are not provided, but can be hallucinated if one considers an average lane width.
     """
 
-    def __init__(self) -> None:
-        """ Initialize the Argoverse Map. """
+    def __init__(self, map_files_root: str = str(MAP_FILES_ROOT)) -> None:
+        """
+         Initialize the Argoverse Map.
+
+        Args:
+           map_files_root: Path to where the map files are stored. By default it is found in $ROOT/map_files.
+        """
+        self.map_files_root = map_files_root
         self.city_name_to_city_id_dict = {"PIT": PITTSBURGH_ID, "MIA": MIAMI_ID}
         self.render_window_radius = 150
         self.im_scale_factor = 50
@@ -159,7 +165,7 @@ class ArgoverseMap:
         """
         city_lane_centerlines_dict = {}
         for city_name, city_id in self.city_name_to_city_id_dict.items():
-            xml_fpath = MAP_FILES_ROOT / f"pruned_argoverse_{city_name}_{city_id}_vector_map.xml"
+            xml_fpath = self.map_files_root + f"/pruned_argoverse_{city_name}_{city_id}_vector_map.xml"
             city_lane_centerlines_dict[city_name] = load_lane_segments_from_xml(xml_fpath)
 
         return city_lane_centerlines_dict
@@ -181,10 +187,10 @@ class ArgoverseMap:
         for city_name, city_id in self.city_name_to_city_id_dict.items():
             city_id = self.city_name_to_city_id_dict[city_name]
             city_rasterized_da_roi_dict[city_name] = {}
-            npy_fpath = MAP_FILES_ROOT / f"{city_name}_{city_id}_driveable_area_mat_2019_05_28.npy"
+            npy_fpath = self.map_files_root + f"/{city_name}_{city_id}_driveable_area_mat_2019_05_28.npy"
             city_rasterized_da_roi_dict[city_name]["da_mat"] = np.load(npy_fpath)
 
-            se2_npy_fpath = MAP_FILES_ROOT / f"{city_name}_{city_id}_npyimage_to_city_se2_2019_05_28.npy"
+            se2_npy_fpath = self.map_files_root + f"/{city_name}_{city_id}_npyimage_to_city_se2_2019_05_28.npy"
             city_rasterized_da_roi_dict[city_name]["npyimage_to_city_se2"] = np.load(se2_npy_fpath)
             da_mat = copy.deepcopy(city_rasterized_da_roi_dict[city_name]["da_mat"])
             city_rasterized_da_roi_dict[city_name]["roi_mat"] = dilate_by_l2(da_mat, dilation_thresh=ROI_ISOCONTOUR)
@@ -204,12 +210,12 @@ class ArgoverseMap:
         city_rasterized_ground_height_dict: Dict[str, Dict[str, np.ndarray]] = {}
         for city_name, city_id in self.city_name_to_city_id_dict.items():
             city_rasterized_ground_height_dict[city_name] = {}
-            npy_fpath = MAP_FILES_ROOT / f"{city_name}_{city_id}_ground_height_mat_2019_05_28.npy"
+            npy_fpath = self.map_files_root + f"/{city_name}_{city_id}_ground_height_mat_2019_05_28.npy"
 
             # load the file with rasterized values
             city_rasterized_ground_height_dict[city_name]["ground_height"] = np.load(npy_fpath)
 
-            se2_npy_fpath = MAP_FILES_ROOT / f"{city_name}_{city_id}_npyimage_to_city_se2_2019_05_28.npy"
+            se2_npy_fpath = self.map_files_root + f"/{city_name}_{city_id}_npyimage_to_city_se2_2019_05_28.npy"
             city_rasterized_ground_height_dict[city_name]["npyimage_to_city_se2"] = np.load(se2_npy_fpath)
 
         return city_rasterized_ground_height_dict
@@ -266,10 +272,10 @@ class ArgoverseMap:
         city_halluc_tableidx_to_laneid_map = {}
 
         for city_name, city_id in self.city_name_to_city_id_dict.items():
-            json_fpath = MAP_FILES_ROOT / f"{city_name}_{city_id}_tableidx_to_laneid_map.json"
+            json_fpath = self.map_files_root + f"/{city_name}_{city_id}_tableidx_to_laneid_map.json"
             city_halluc_tableidx_to_laneid_map[city_name] = read_json_file(json_fpath)
 
-            npy_fpath = MAP_FILES_ROOT / f"{city_name}_{city_id}_halluc_bbox_table.npy"
+            npy_fpath = self.map_files_root + f"/{city_name}_{city_id}_halluc_bbox_table.npy"
             city_halluc_bbox_table[city_name] = np.load(npy_fpath)
 
         return city_halluc_bbox_table, city_halluc_tableidx_to_laneid_map


### PR DESCRIPTION
In this PR we add `map_files_root` in `ArgoverseMap` during initialization to make it flexible in accessing maps at different paths.

The default remains to be `$ROOT/map_files` to ensure backward compatibility.