### PR TITLE
Increase readability by placing global constants in a config

### DIFF
--- a/argoverse/config/argoverse1.1.yml
+++ b/argoverse/config/argoverse1.1.yml
@@ -1,0 +1,54 @@
+SensorDatasetConfig:
+  _target_: argoverse.sensor_dataset_config.SensorDatasetConfig
+  dataset_name: argoverse1.1
+  ring_cam_fps: 30
+  stereo_cam_fps: 5
+
+  # all ring cameras are `landscape` aspect ratio
+  sensors:
+    _target_: argoverse.sensor_dataset_config.SensorDimensions
+    
+    ring_front_center: 
+      _target_: argoverse.sensor_dataset_config.ImageDimensions
+      height: 1200
+      width: 1920
+
+    ring_front_left:
+      _target_: argoverse.sensor_dataset_config.ImageDimensions
+      height: 1200
+      width: 1920
+
+    ring_front_right:
+      _target_: argoverse.sensor_dataset_config.ImageDimensions
+      height: 1200
+      width: 1920
+
+    ring_side_left:
+      _target_: argoverse.sensor_dataset_config.ImageDimensions
+      height: 1200
+      width: 1920
+
+    ring_side_right:
+      _target_: argoverse.sensor_dataset_config.ImageDimensions
+      height: 1200
+      width: 1920
+
+    ring_rear_left:
+      _target_: argoverse.sensor_dataset_config.ImageDimensions
+      height: 1200
+      width: 1920
+
+    ring_rear_right:
+      _target_: argoverse.sensor_dataset_config.ImageDimensions
+      height: 1200
+      width: 1920
+
+    stereo_front_right:
+      _target_: argoverse.sensor_dataset_config.ImageDimensions
+      height: 2056
+      width: 2464
+
+    stereo_front_left:
+      _target_: argoverse.sensor_dataset_config.ImageDimensions
+      height: 2056
+      width: 2464

--- a/argoverse/sensor_dataset_config.py
+++ b/argoverse/sensor_dataset_config.py
@@ -1,0 +1,35 @@
+
+from typing import NamedTuple, Optional, Tuple
+
+from hydra.experimental import compose, initialize_config_module
+from hydra.utils import instantiate
+
+
+class ImageDimensions(NamedTuple):
+    """Dimensions are provided as (height, width)"""
+    height: int
+    width: int
+
+class SensorDimensions(NamedTuple):
+    ring_front_center: ImageDimensions
+    ring_front_left: ImageDimensions
+    ring_front_right: ImageDimensions
+    ring_side_left: ImageDimensions
+    ring_side_right: ImageDimensions
+    ring_rear_left: ImageDimensions
+    ring_rear_right: ImageDimensions
+    stereo_front_right: Optional[ImageDimensions]
+    stereo_front_left: Optional[ImageDimensions]
+
+class SensorDatasetConfig(NamedTuple):
+    dataset_name: str
+    ring_cam_fps: int
+    stereo_cam_fps: int
+    sensors: SensorDimensions
+
+DATASET_NAME = "argoverse1.1"
+
+with initialize_config_module(config_module="argoverse.config"):
+    cfg = compose(config_name="argoverse1.1.yml")
+    ArgoverseConfig: SensorDatasetConfig = instantiate(cfg.SensorDatasetConfig)
+

--- a/argoverse/sensor_dataset_config.py
+++ b/argoverse/sensor_dataset_config.py
@@ -1,5 +1,5 @@
 
-from typing import NamedTuple, Optional, Tuple
+from typing import NamedTuple, Optional
 
 from hydra.experimental import compose, initialize_config_module
 from hydra.utils import instantiate

--- a/argoverse/sensor_dataset_config.py
+++ b/argoverse/sensor_dataset_config.py
@@ -30,6 +30,6 @@ class SensorDatasetConfig(NamedTuple):
 DATASET_NAME = "argoverse1.1"
 
 with initialize_config_module(config_module="argoverse.config"):
-    cfg = compose(config_name="argoverse1.1.yml")
+    cfg = compose(config_name=f"{DATASET_NAME}.yml")
     ArgoverseConfig: SensorDatasetConfig = instantiate(cfg.SensorDatasetConfig)
 

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,9 @@ setup(
         "colour",
         "descartes",
         "imageio",
+        "h5py",
+        "hydra-core==1.1.0dev3",
+        "lap",
         "matplotlib",
         "motmetrics==1.1.3",
         "numpy==1.19",
@@ -63,9 +66,7 @@ setup(
         "scipy>=1.4.0",
         "shapely",
         "sklearn",
-        "typing_extensions",
-        "h5py",
-        "lap",
+        "typing_extensions"
     ],
     # for older pip version, use with --process-dependency-links
     dependency_links=["git+https://github.com/daavoo/pyntcloud#egg=pyntcloud-0.1.0"],


### PR DESCRIPTION
Currently, global constants like frame rate and image dimensions are scattered across the codebase, including in `data_loading/synchronization_database.py` and  `utils/camera_stats.py`. This PR places them in a more intuitive place for the user -- a single config file -- increasing readability for the codebase.