### PR TITLE
Re-normalize quaternions if norm !=1, instead of throwing error

### DIFF
--- a/argoverse/utils/transform.py
+++ b/argoverse/utils/transform.py
@@ -7,8 +7,12 @@ while avoiding singularities or discontinuities (e.g. gimbal lock).
 We require that the quaternions are normalized beforehand to be unit-length.
 """
 
+import logging
+
 import numpy as np
 from scipy.spatial.transform import Rotation
+
+logger = logging.getLogger(__name__)
 
 
 def quat2rotmat(q: np.ndarray) -> np.ndarray:
@@ -25,9 +29,12 @@ def quat2rotmat(q: np.ndarray) -> np.ndarray:
     Returns:
         R: Array of shape (3, 3) representing a rotation matrix.
     """
-    if not np.isclose(np.linalg.norm(q), 1.0, atol=1e-12):
-        # forced to re-normalize quaternion, since its norm was not equal to 1
-        q /= np.linalg.norm(q)
+    norm = np.linalg.norm(q)
+    if not np.isclose(norm, 1.0, atol=1e-12):
+        logger.info("Forced to re-normalize quaternion, since its norm was not equal to 1.")
+        if np.isclose(norm, 0.0):
+            raise ZeroDivisionError("Normalize quaternioning with norm=0 would lead to division by zero.")
+        q /= norm
 
     quat_xyzw = quat_argo2scipy(q)
     return Rotation.from_quat(quat_xyzw).as_matrix()

--- a/argoverse/utils/transform.py
+++ b/argoverse/utils/transform.py
@@ -4,7 +4,8 @@
 Unit quaternions are a way to compactly represent 3D rotations
 while avoiding singularities or discontinuities (e.g. gimbal lock).
 
-We require that the quaternions are normalized beforehand to be unit-length.
+If a quaternion is not normalized beforehand to be unit-length, we will
+re-normalize it on the fly.
 """
 
 import logging
@@ -16,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 def quat2rotmat(q: np.ndarray) -> np.ndarray:
-    """Convert a unit-length quaternion into a rotation matrix.
+    """Normalizes a quaternion to unit-length, then converts it into a rotation matrix.
 
     Note that libraries such as Scipy expect a quaternion in scalar-last [x, y, z, w] format,
     whereas at Argo we work with scalar-first [w, x, y, z] format, so we convert between the

--- a/argoverse/utils/transform.py
+++ b/argoverse/utils/transform.py
@@ -25,7 +25,9 @@ def quat2rotmat(q: np.ndarray) -> np.ndarray:
     Returns:
         R: Array of shape (3, 3) representing a rotation matrix.
     """
-    assert np.isclose(np.linalg.norm(q), 1.0, atol=1e-12)
+    if not np.isclose(np.linalg.norm(q), 1.0, atol=1e-12):
+        # forced to re-normalize quaternion, since its norm was not equal to 1
+        q /= np.linalg.norm(q)
 
     quat_xyzw = quat_argo2scipy(q)
     return Rotation.from_quat(quat_xyzw).as_matrix()

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -6,6 +6,7 @@ utility yields the correct result given the swapped argument order.
 """
 
 import numpy as np
+import pytest
 
 from argoverse.utils.transform import quat2rotmat
 
@@ -145,3 +146,25 @@ def test_quat2rotmat_5() -> None:
         ]
     )
     assert np.allclose(R_gt, R)
+
+
+def test_invalid_quaternion_zero_norm():
+    """Ensure that passing a zero-norm quaternion raises an error, as normalization would divide by 0."""
+    q = np.array([0.0, 0.0, 0.0, 0.0])
+
+    with pytest.raises(ZeroDivisionError) as e_info:
+        R = quat2rotmat(q)
+
+
+def test_quaternion_renormalized():
+    """Make sure that a quaternion is correctly re-normalized.
+
+    Normalized and unnormalized quaternion variants should generate the same 3d rotation matrix.
+    """
+    q1 = np.array([0.0, 0.0, 0.0, 1.0])
+    R1 = quat2rotmat(q1)
+
+    q2 = np.array([0.0, 0.0, 0.0, 2.0])
+    R2 = quat2rotmat(q2)
+
+    assert np.allclose(R1, R2)


### PR DESCRIPTION
A user may provide a quaternion that does not have exactly unit norm. Instead of throwing an error (previous behavior), we can simply re-normalize the quaternion and gracefully proceed.