### PR TITLE
Limit max number of scores associated with max boxes.

### DIFF
--- a/argoverse/evaluation/detection/eval.py
+++ b/argoverse/evaluation/detection/eval.py
@@ -238,7 +238,6 @@ def main() -> None:
 
     evaluator = DetectionEvaluator(dt_fpath, gt_fpath, fig_fpath, num_procs=args.num_processes)
     metrics = evaluator.evaluate()
-    print(metrics)
 
 
 if __name__ == "__main__":

--- a/argoverse/evaluation/detection/eval.py
+++ b/argoverse/evaluation/detection/eval.py
@@ -238,6 +238,7 @@ def main() -> None:
 
     evaluator = DetectionEvaluator(dt_fpath, gt_fpath, fig_fpath, num_procs=args.num_processes)
     metrics = evaluator.evaluate()
+    print(metrics)
 
 
 if __name__ == "__main__":

--- a/argoverse/evaluation/detection/utils.py
+++ b/argoverse/evaluation/detection/utils.py
@@ -329,7 +329,7 @@ def rank(dts: np.ndarray) -> np.ndarray:
         dts: Array of `ObjectLabelRecord` objects. (N,).
 
     Returns:
-        ranked_dts: Array of `ObjectLabelRecord` objects ranked by score. (MAX_NUM_BOXES,).
+        ranked_dts: Array of `ObjectLabelRecord` objects ranked by score. (N,) where N <= MAX_NUM_BOXES
     """
     scores = np.array([dt.score for dt in dts.tolist()])
     ranks = scores.argsort()[::-1]

--- a/argoverse/evaluation/detection/utils.py
+++ b/argoverse/evaluation/detection/utils.py
@@ -92,7 +92,7 @@ class DetectionCfg(NamedTuple):
     dt_classes: List[str] = COMPETITION_CLASSES
     dt_metric: FilterMetric = FilterMetric.EUCLIDEAN
     max_dt_range: float = 100.0  # Meters
-    save_figs: bool = True
+    save_figs: bool = False
     tp_normalization_terms: np.ndarray = np.array([tp_thresh, MAX_SCALE_ERROR, MAX_YAW_ERROR])
     summary_default_vals: np.ndarray = np.array([MIN_AP, tp_thresh, MAX_NORMALIZED_ASE, MAX_NORMALIZED_AOE, MIN_CDS])
     eval_only_roi_instances: bool = True

--- a/argoverse/evaluation/detection/utils.py
+++ b/argoverse/evaluation/detection/utils.py
@@ -157,10 +157,10 @@ def accumulate(
         logger.info(f"{dt_filtered.shape[0]} detections")
         logger.info(f"{gt_filtered.shape[0]} ground truth")
         if dt_filtered.shape[0] > 0:
-            ranked_label_records = rank(dt_filtered)
-            metrics = assign(ranked_label_records, gt_filtered, cfg)
+            ranked_dts = rank(dt_filtered)
+            metrics = assign(ranked_dts, gt_filtered, cfg)
 
-            scores = [[record.score] for record in ranked_label_records.tolist()]
+            scores = [[record.score] for record in ranked_dts.tolist()]
             cls_to_accum[class_name] = np.hstack((metrics, scores))
 
         cls_to_ninst[class_name] = gt_filtered.shape[0]
@@ -321,24 +321,24 @@ def filter_instances(
     return filtered_instances
 
 
-def rank(label_records: np.ndarray) -> np.ndarray:
+def rank(dts: np.ndarray) -> np.ndarray:
     """Rank the `ObjectLabelRecord` objects in descending order by score.
 
     Args:
-        label_records: Array of `ObjectLabelRecord` objects. (N,).
+        dts: Array of `ObjectLabelRecord` objects. (N,).
 
     Returns:
-        ranked_label_records: Array of `ObjectLabelRecord` objects ranked by score. (N,).
+        ranked_dts: Array of `ObjectLabelRecord` objects ranked by score. (N,).
     """
-    scores = np.array([dt.score for dt in label_records.tolist()])
+    scores = np.array([dt.score for dt in dts.tolist()])
     ranks = scores.argsort()[::-1]
 
-    ranked_label_records = label_records[ranks]
+    ranked_dts = dts[ranks]
 
     # Ensure the number of boxes considered per class is at most `MAX_NUM_BOXES`.
-    if ranked_label_records.shape[0] > MAX_NUM_BOXES:
-        ranked_label_records = ranked_label_records[:MAX_NUM_BOXES]
-    return ranked_label_records
+    if ranked_dts.shape[0] > MAX_NUM_BOXES:
+        ranked_dts = ranked_dts[:MAX_NUM_BOXES]
+    return ranked_dts
 
 
 def interp(prec: np.ndarray, method: InterpType = InterpType.ALL) -> np.ndarray:

--- a/argoverse/evaluation/detection/utils.py
+++ b/argoverse/evaluation/detection/utils.py
@@ -95,7 +95,7 @@ class DetectionCfg(NamedTuple):
     save_figs: bool = True
     tp_normalization_terms: np.ndarray = np.array([tp_thresh, MAX_SCALE_ERROR, MAX_YAW_ERROR])
     summary_default_vals: np.ndarray = np.array([MIN_AP, tp_thresh, MAX_NORMALIZED_ASE, MAX_NORMALIZED_AOE, MIN_CDS])
-    eval_only_roi_instances: bool = False
+    eval_only_roi_instances: bool = True
     map_root: _PathLike = Path(__file__).parent.parent.parent.parent / "map_files"  # argoverse-api/map_files
 
 

--- a/argoverse/evaluation/detection/utils.py
+++ b/argoverse/evaluation/detection/utils.py
@@ -322,13 +322,14 @@ def filter_instances(
 
 
 def rank(dts: np.ndarray) -> np.ndarray:
-    """Rank the `ObjectLabelRecord` objects in descending order by score.
+    """Rank the detections in descending order according to score (detector confidence).
+
 
     Args:
         dts: Array of `ObjectLabelRecord` objects. (N,).
 
     Returns:
-        ranked_dts: Array of `ObjectLabelRecord` objects ranked by score. (N,).
+        ranked_dts: Array of `ObjectLabelRecord` objects ranked by score. (MAX_NUM_BOXES,).
     """
     scores = np.array([dt.score for dt in dts.tolist()])
     ranks = scores.argsort()[::-1]


### PR DESCRIPTION
Fixes two issues:

1. Corrects typing of args in `rank`.
2. The scores array was incorrect when the number of detections exceeded the maximum allowed.
3. Scores are sorted now in the case that someone submits unordered detections.