### PR TITLE
Add pyproject.toml

### DIFF
--- a/argoverse/evaluation/detection/utils.py
+++ b/argoverse/evaluation/detection/utils.py
@@ -338,10 +338,7 @@ def rank(dts: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     ranked_scores = scores[ranks]
 
     # Ensure the number of boxes considered per class is at most `MAX_NUM_BOXES`.
-    if ranked_dts.shape[0] > MAX_NUM_BOXES:
-        ranked_dts = ranked_dts[:MAX_NUM_BOXES]
-        ranked_scores = ranked_scores[:MAX_NUM_BOXES]
-    return ranked_dts, ranked_scores
+    return ranked_dts[:MAX_NUM_BOXES], ranked_scores[:MAX_NUM_BOXES]
 
 
 def interp(prec: np.ndarray, method: InterpType = InterpType.ALL) -> np.ndarray:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,5 @@ line_length = 120
 multi_line_output = 3
 profile = "black"
 
-
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
-[settings]
-known_first_party=argoverse
-# cat setup.py | grep -Pzo "(?s)install_requires.+?]" | tail -n+2 | head -n-1 | grep -Po '"[a-zA-Z0-9]+' | sed 's/"/,/'
+[tool.isort]
+known_first_party = argoverse
 known_third_party=mayavi,pytest,colour,descartes,imageio,matplotlib,motmetrics,numpy,cv2,pandas,pillow,imageio,pyntcloud,scipy,shapely,sklearn
 line_length = 120
+multi_line_output = 3
+profile = "black"
+
+
+[tool.black]
+line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.isort]
 known_first_party = argoverse
-known_third_party = mayavi,pytest,colour,descartes,imageio,matplotlib,motmetrics,numpy,cv2,pandas,pillow,imageio,pyntcloud,scipy,shapely,sklearn
 line_length = 120
 multi_line_output = 3
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.isort]
 known_first_party = argoverse
-known_third_party=mayavi,pytest,colour,descartes,imageio,matplotlib,motmetrics,numpy,cv2,pandas,pillow,imageio,pyntcloud,scipy,shapely,sklearn
+known_third_party = mayavi,pytest,colour,descartes,imageio,matplotlib,motmetrics,numpy,cv2,pandas,pillow,imageio,pyntcloud,scipy,shapely,sklearn
 line_length = 120
 multi_line_output = 3
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.isort]
-known_first_party = argoverse
+known_first_party = "argoverse"
 line_length = 120
 multi_line_output = 3
 profile = "black"


### PR DESCRIPTION
This PR adds a `pyproject.toml` file to consolidate styling tools such as `isort` and `black`.

- `pyproject.toml` was introduced in [PEP 518](https://www.python.org/dev/peps/pep-0518/) for build system requirements.
- Allows for a unified configuration file for a host of tools, e.g. `isort`, `black`, etc.

Each "block" within this file specifies a different type of options. For example, `isort` is written as:

```
[tool.isort]

known_first_party = "argoverse"
line_length = 120
multi_line_output = 3
profile = "black"
```

The options above should have a 1-to-1 correspondence with `isort.cfg`. 