### PR TITLE
Added pyproject.toml.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,0 @@
-[settings]
-known_first_party=argoverse
-# cat setup.py | grep -Pzo "(?s)install_requires.+?]" | tail -n+2 | head -n-1 | grep -Po '"[a-zA-Z0-9]+' | sed 's/"/,/'
-known_third_party=mayavi,pytest,colour,descartes,imageio,matplotlib,motmetrics,numpy,cv2,pandas,pillow,imageio,pyntcloud,scipy,shapely,sklearn
-line_length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.isort]
+known_first_party = "argoverse"
+line_length = 120
+multi_line_output = 3
+profile = "black"
+
+[tool.black]
+line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [tool.isort]
 known_first_party = "argoverse"
+known_third_party = "mayavi,pytest,colour,descartes,imageio,matplotlib,motmetrics,numpy,cv2,pandas,pillow,imageio,pyntcloud,scipy,shapely,sklearn"
+
 line_length = 120
 multi_line_output = 3
 profile = "black"


### PR DESCRIPTION
# Overview

This PR adds a `pyproject.toml` file to consolidate styling tools such as `isort` and `black`.

- `pyproject.toml` was introduced in [PEP 518](https://www.python.org/dev/peps/pep-0518/) for build system requirements.
- Allows for a unified configuration file for a host of tools, e.g. `isort`, `black`, etc.

Each "block" within this file specifies a different type of options. For example, `isort` is written as:

```
[tool.isort]

known_first_party = "argoverse"
line_length = 120
multi_line_output = 3
profile = "black"
```

The options above should have a 1-to-1 correspondence with `isort.cfg`. 

# Advantages

- Modern, consolidated project configuration
-  Lays groundwork for [poetry](https://python-poetry.org/) integration.