### PR TITLE
Update README.md badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/)
 [![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/downloads/release/python-370/)
+[![Python 3.8](https://img.shields.io/badge/python-3.8-blue.svg)](https://www.python.org/downloads/release/python-380/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 ![Linux CI](https://github.com/argoai/argoverse-api/workflows/Python%20CI/badge.svg)
 


### PR DESCRIPTION
We don't support `python <3.7` any longer. These updated badges reflect this.