### PR TITLE
Throw exception if input to Sim(2)'s `transform_from()` is not 2d

### DIFF
--- a/argoverse/utils/sim2.py
+++ b/argoverse/utils/sim2.py
@@ -98,6 +98,8 @@ class Sim2:
         Returns:
             transformed_point_cloud: Nx2 array representing 2d points in frame B
         """
+        if not point_cloud.ndim == 2:
+            raise ValueError("Input point cloud is not 2-dimensional.")
         assert_np_array_shape(point_cloud, (None, 2))
         # (2,2) x (2,N) + (2,1) = (2,N) -> transpose
         transformed_point_cloud = (self.R_ @ point_cloud.T + self.t_.reshape(2, 1)).T

--- a/argoverse/utils/sim2.py
+++ b/argoverse/utils/sim2.py
@@ -102,7 +102,7 @@ class Sim2:
             raise ValueError("Input point cloud is not 2-dimensional.")
         assert_np_array_shape(point_cloud, (None, 2))
         # (2,2) x (2,N) + (2,1) = (2,N) -> transpose
-        transformed_point_cloud = (self.R_ @ point_cloud.T + self.t_.reshape(2, 1)).T
+        transformed_point_cloud = (point_cloud @ self.R_.T) + self.t_
 
         # now scale points
         return transformed_point_cloud * self.s_

--- a/tests/test_sim2.py
+++ b/tests/test_sim2.py
@@ -193,3 +193,14 @@ def test_cannot_set_zero_scale() -> None:
 
     with pytest.raises(ZeroDivisionError) as e_info:
         Sim2(R, t, s)
+
+
+def test_transform_from_wrong_dims() -> None:
+    """Ensure that 1d input is not allowed (row vectors are required, as Nx2)."""
+    bRa = np.eye(2)
+    bta = np.array([1, 2])
+    bsa = 3.0
+    bSa = Sim2(R=bRa, t=bta, s=bsa)
+
+    with pytest.raises(ValueError) as e_info:
+        val = bSa.transform_from(np.array([1.0, 3.0]))


### PR DESCRIPTION
Input must be (N,2) not (2,) in shape.

Using the previous code, a (2,) array vs. (1,2) array would yield different results:
```python
import numpy as np

from argoverse.utils.sim2 import Sim2


def rotmat2d(theta_deg: float) -> np.ndarray:
	""" """
	theta_rad = np.deg2rad(theta_deg)
	c = np.cos(theta_rad)
	s = np.sin(theta_rad)

	R = np.array([[c,-s],[s,c]])

	return R

R = rotmat2d(-13)
t = np.array([-5,1])
s = 1.5
aSb = Sim2(R, t, s)

pt_b = np.array([1,0])
pt_a = aSb.transform_from(pt_b)
print(pt_a)

pt_b = np.array([1,0]).reshape(1,2)
pt_a = aSb.transform_from(pt_b)
print(pt_a)
```
used to print:
```
[[-6.03844491  2.96155509]
 [-7.83742659  1.16257341]]
[[-6.03844491  1.16257341]]
```
Instead, there should be the same (1,2) array as output.

Now, fixed via broadcasting.