### PR TITLE
Fix matmul bug and add __repr__ method to Sim2

### DIFF
--- a/argoverse/utils/sim2.py
+++ b/argoverse/utils/sim2.py
@@ -37,11 +37,16 @@ class Sim2:
 
     @property
     def theta_deg(self) -> float:
-        """Recover the rotation angle `theta` from the 2d rotation matrix.
+        """Recover the rotation angle `theta` (in degrees) from the 2d rotation matrix.
 
-        Note: tan(theta) = s/c = (opp/hyp) / (adj/hyp) = opp/adj
+        Note: the first column of the rotation matrix R provides sine and cosine of theta,
+            since R is encoded as [c,-s]
+                                  [s, c]
+
+        We use the following identity: tan(theta) = s/c = (opp/hyp) / (adj/hyp) = opp/adj
         """
-        theta_rad = np.arctan2(self.R_[1, 0], self.R_[0, 0])
+        c, s = self.R_[0, 0], self.R_[1, 0]
+        theta_rad = np.arctan2(s, c)
         return np.rad2deg(theta_rad)
 
     def __repr__(self) -> str:

--- a/argoverse/utils/sim2.py
+++ b/argoverse/utils/sim2.py
@@ -94,8 +94,21 @@ class Sim2:
         return T
 
     def compose(self, S: "Sim2") -> "Sim2":
-        """Composition with another Sim2."""
-        return Sim2(self.R_ @ S.R_, ((1.0 / S.s_) * self.t_) + self.R_ @ S.t_, self.s_ * S.s_)
+        """Composition with another Sim2.
+
+        This can be understood via block matrix multiplication, if self is parameterized as (R1,t1,s1)
+        and if `S` is parameterized as (R2,t2,s2):
+
+        [R1  t1]   [R2  t2]   [R1 @ R2   R1@t2 + t1/s2]
+        [0 1/s1] @ [0 1/s2] = [ 0          1/(s1*s2)  ]
+        """
+        # fmt: off
+        return Sim2(
+            R=self.R_ @ S.R_,
+            t=self.R_ @ S.t_ + ((1.0 / S.s_) * self.t_),
+            s=self.s_ * S.s_
+        )
+        # fmt: on
 
     def inverse(self) -> "Sim2":
         """Return the inverse."""

--- a/argoverse/utils/sim2.py
+++ b/argoverse/utils/sim2.py
@@ -54,7 +54,7 @@ class Sim2:
         return f"Angle (deg.): {self.theta_deg}, Trans.: {np.round(self.t_,2)}, Scale: {self.s_}"
 
     def __eq__(self, other: object) -> bool:
-        """Check for equality with other Sim(2) object"""
+        """Check for equality with other Sim(2) object."""
         if not isinstance(other, Sim2):
             return False
 

--- a/argoverse/utils/sim2.py
+++ b/argoverse/utils/sim2.py
@@ -47,7 +47,7 @@ class Sim2:
         """
         c, s = self.R_[0, 0], self.R_[1, 0]
         theta_rad = np.arctan2(s, c)
-        return np.rad2deg(theta_rad)
+        return float(np.rad2deg(theta_rad))
 
     def __repr__(self) -> str:
         """Return a human-readable string representation of the class."""

--- a/argoverse/utils/sim2.py
+++ b/argoverse/utils/sim2.py
@@ -45,7 +45,7 @@ class Sim2:
         return np.rad2deg(theta_rad)
 
     def __repr__(self) -> str:
-        """ """
+        """Return a human-readable string representation of the class."""
         return f"Angle (deg.): {self.theta_deg}, Trans.: {np.round(self.t_,2)}, Scale: {self.s_}"
 
     def __eq__(self, other: object) -> bool:

--- a/argoverse/utils/sim2.py
+++ b/argoverse/utils/sim2.py
@@ -71,12 +71,12 @@ class Sim2:
 
     @property
     def rotation(self) -> np.ndarray:
-        """Return the 2x2 rotation matrix"""
+        """Return the 2x2 rotation matrix."""
         return self.R_
 
     @property
     def translation(self) -> np.ndarray:
-        """Return the (2,) translation vector"""
+        """Return the (2,) translation vector."""
         return self.t_
 
     @property
@@ -86,7 +86,7 @@ class Sim2:
 
     @property
     def matrix(self) -> np.ndarray:
-        """Calculate 3*3 matrix group equivalent"""
+        """Calculate 3*3 matrix group equivalent."""
         T = np.zeros((3, 3))
         T[:2, :2] = self.R_
         T[:2, 2] = self.t_

--- a/argoverse/utils/sim2.py
+++ b/argoverse/utils/sim2.py
@@ -35,6 +35,19 @@ class Sim2:
         self.t_ = t.astype(np.float32)
         self.s_ = float(s)
 
+    @property
+    def theta_deg(self) -> float:
+        """Recover the rotation angle `theta` from the 2d rotation matrix.
+
+        Note: tan(theta) = s/c = (opp/hyp) / (adj/hyp) = opp/adj
+        """
+        theta_rad = np.arctan2(self.R_[1, 0], self.R_[0, 0])
+        return np.rad2deg(theta_rad)
+
+    def __repr__(self) -> str:
+        """ """
+        return f"Angle (deg.): {self.theta_deg}, Trans.: {np.round(self.t_,2)}, Scale: {self.s_}"
+
     def __eq__(self, other: object) -> bool:
         """Check for equality with other Sim(2) object"""
         if not isinstance(other, Sim2):
@@ -77,7 +90,7 @@ class Sim2:
 
     def compose(self, S: "Sim2") -> "Sim2":
         """Composition with another Sim2."""
-        return Sim2(self.R_ * S.R_, ((1.0 / S.s_) * self.t_) + self.R_ @ S.t_, self.s_ * S.s_)
+        return Sim2(self.R_ @ S.R_, ((1.0 / S.s_) * self.t_) + self.R_ @ S.t_, self.s_ * S.s_)
 
     def inverse(self) -> "Sim2":
         """Return the inverse."""

--- a/tests/test_sim2.py
+++ b/tests/test_sim2.py
@@ -234,13 +234,13 @@ def test_sim2_theta_deg_1() -> None:
     assert aSb.theta_deg == 0
 
 
-def test_sim2_theta_deg_1() -> None:
+def test_sim2_theta_deg_2() -> None:
     """Ensure we can recover the rotation angle theta"""
-    R = np.eye(2)
+    R = rotmat2d(np.deg2rad(135))
     t = np.arange(2)
     s = 10.5
     aSb = Sim2(R, t, s)
-    assert aSb.theta_deg == 0
+    assert aSb.theta_deg == 135
 
 
 def test_sim2_repr() -> None:

--- a/tests/test_sim2.py
+++ b/tests/test_sim2.py
@@ -120,7 +120,7 @@ def test_compose_3() -> None:
 
 
 def test_inverse() -> None:
-    """ """
+    """Ensure that the .inverse() method returns the correct result."""
     scale = 2.0
     imgSw = Sim2(R=np.eye(2), t=np.array([1.0, 3.0]), s=scale)
 
@@ -226,7 +226,7 @@ def test_cannot_set_zero_scale() -> None:
 
 
 def test_sim2_theta_deg_1() -> None:
-    """Ensure we can recover the rotation angle theta"""
+    """Ensure we can recover the rotation angle theta, when theta=0 degrees."""
     R = np.eye(2)
     t = np.arange(2)
     s = 10.5
@@ -235,7 +235,7 @@ def test_sim2_theta_deg_1() -> None:
 
 
 def test_sim2_theta_deg_2() -> None:
-    """Ensure we can recover the rotation angle theta"""
+    """Ensure we can recover the rotation angle theta, when theta=135 degrees."""
     R = rotmat2d(np.deg2rad(135))
     t = np.arange(2)
     s = 10.5

--- a/tests/test_sim2.py
+++ b/tests/test_sim2.py
@@ -76,8 +76,8 @@ def test_scale() -> None:
     assert bSa.scale == 3.0
 
 
-def test_compose():
-    """Ensure we can compose two Sim(2) transforms together."""
+def test_compose_1() -> None:
+    """Ensure we can compose two Sim(2) transforms together, with identity rotations."""
     scale = 2.0
     imgSw = Sim2(R=np.eye(2), t=np.array([1.0, 3.0]), s=scale)
 
@@ -89,7 +89,37 @@ def test_compose():
     assert wSw == imgSw.compose(wSimg)
 
 
-def test_inverse():
+def test_compose_2() -> None:
+    """Verify composition of Sim2 objects works for non-identity input."""
+    aSb = Sim2(R=rotmat2d(np.deg2rad(90)), t=np.array([1, 2]), s=4)
+
+    bSc = Sim2(R=rotmat2d(np.deg2rad(-45)), t=np.array([3, 4]), s=0.5)
+
+    aSc = aSb.compose(bSc)
+    # Via composition: 90 + -45 = 45 degrees
+    assert aSc.theta_deg == 45.0
+    # Via composition: 4 * 0.5 = 2.0
+    assert aSc.scale == 2.0
+
+
+def test_compose_3() -> None:
+    """Verify correctness of composed inverted and non-inverted transformations."""
+
+    # Note: these are dummy translation values; should be ignored when considering correctness
+    aSb = Sim2(R=rotmat2d(np.deg2rad(20)), t=np.array([1, 2]), s=2)
+
+    bSc = Sim2(R=rotmat2d(np.deg2rad(30)), t=np.array([1, 2]), s=3)
+
+    aSc = Sim2(R=rotmat2d(np.deg2rad(50)), t=np.array([1, 2]), s=6)
+
+    # ground truth is an identity transformation
+    aSa_gt = Sim2(R=np.eye(2), t=np.zeros(2), s=1.0)
+    aSa_est = aSb.compose(bSc).compose(aSc.inverse())
+
+    assert np.isclose(aSa_gt.theta_deg, aSa_est.theta_deg, atol=1e-5)
+
+
+def test_inverse() -> None:
     """ """
     scale = 2.0
     imgSw = Sim2(R=np.eye(2), t=np.array([1.0, 3.0]), s=scale)
@@ -193,3 +223,31 @@ def test_cannot_set_zero_scale() -> None:
 
     with pytest.raises(ZeroDivisionError) as e_info:
         Sim2(R, t, s)
+
+
+def test_sim2_theta_deg_1() -> None:
+    """Ensure we can recover the rotation angle theta"""
+    R = np.eye(2)
+    t = np.arange(2)
+    s = 10.5
+    aSb = Sim2(R, t, s)
+    assert aSb.theta_deg == 0
+
+
+def test_sim2_theta_deg_1() -> None:
+    """Ensure we can recover the rotation angle theta"""
+    R = np.eye(2)
+    t = np.arange(2)
+    s = 10.5
+    aSb = Sim2(R, t, s)
+    assert aSb.theta_deg == 0
+
+
+def test_sim2_repr() -> None:
+    """Ensure we can print the class, and obtain the correct string representation from __repr__."""
+    R = np.eye(2)
+    t = np.arange(2)
+    s = 10.5
+    aSb = Sim2(R, t, s)
+    print(aSb)
+    assert repr(aSb) == "Angle (deg.): 0.0, Trans.: [0. 1.], Scale: 10.5"


### PR DESCRIPTION
Previously, the `compose()` method had a bug ( R1 * R2 was used instead of the correct R1 @ R2) that was not caught since the unit test used identity matrices, for which the operations are identical.

This PR also adds a __repr__ method for helpful printing/debugging of the class representation.