### PR TITLE
Update for deprecated types.

### DIFF
--- a/argoverse/evaluation/detection/utils.py
+++ b/argoverse/evaluation/detection/utils.py
@@ -412,8 +412,8 @@ def calc_ap(gt_ranked: np.ndarray, recalls_interp: np.ndarray, ninst: int) -> Tu
     """
     tp = gt_ranked
 
-    cumulative_tp = np.cumsum(tp, dtype=np.int)
-    cumulative_fp = np.cumsum(~tp, dtype=np.int)
+    cumulative_tp = np.cumsum(tp, dtype=int)
+    cumulative_fp = np.cumsum(~tp, dtype=int)
     cumulative_fn = ninst - cumulative_tp
 
     precisions = cumulative_tp / (cumulative_tp + cumulative_fp + np.finfo(float).eps)

--- a/argoverse/utils/make_att_files.py
+++ b/argoverse/utils/make_att_files.py
@@ -115,7 +115,7 @@ def save_bev_img(
             )
             cv2.line(img, p1, p2, color=color)
 
-    kernel = np.ones((5, 5), np.float)
+    kernel = np.ones((5, 5), float)
     img = cv2.dilate(img, kernel, iterations=1)
     cv2.putText(
         img,


### PR DESCRIPTION
This maps `np.int` -> `int` and `np.float` -> `float` as the former values are deprecated aliases of the latter.