### PR TITLE
Remove ipynb ckpts and replace numba install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ tests/test_data/tmp
 .vscode
 tests/test_data/1obj_*.txt
 tests/test_data/mot16_scenario_*.txt
+
+.ipynb_checkpoints

--- a/README.md
+++ b/README.md
@@ -76,12 +76,11 @@ Make sure that you can run `python -c "import argoverse"` in python, and you are
 * Some visualizations may require `mayavi`. See instructions on how to install Mayavi [here](https://docs.enthought.com/mayavi/mayavi/installation.html).
 
 ### (optional) Stereo tutorial dependencies
-* You will need to install four dependencies to run the [stereo tutorial](https://github.com/argoai/argoverse-api/blob/master/demo_usage/competition_stereo_tutorial.ipynb):
+* You will need to install three dependencies to run the [stereo tutorial](https://github.com/argoai/argoverse-api/blob/master/demo_usage/competition_stereo_tutorial.ipynb):
 
     * **Open3D**: See instructions on how to install [here](https://github.com/intel-isl/Open3D).
     * **OpenCV contrib**: See instructions on how to install [here](https://pypi.org/project/opencv-contrib-python).
     * **Plotly**: See instructions on how to install [here](https://github.com/plotly/plotly.py).
-    * **Numba**: See instructions on how to install [here](http://numba.pydata.org/).
 
 ### (optional) Remake the object-oriented label folders
 * The `track_labels_amodal` folders contains object-oriented labels (in contrast to per-frame labels in `per_sweep_annotations_amodal` folders. Run following script to remake `track_labels_amodal` folders and fix existing issues:

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "lap",
         "matplotlib",
         "motmetrics==1.1.3",
+        "numba",
         "numpy==1.19",
         "omegaconf==2.1.0",
         "opencv-python>=4.1.0.25",

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ deps =
     flake8-string-format
 
 commands =
-   python3 -m pip install numba
    pytest tests --cov argoverse --cov-append --cov-branch --cov-report=term-missing
    flake8 --max-line-length 120 --ignore E203,E704,E711,E722,E741,W291,W293,W391,W503,F821,F401,F811,F841,P101,G004,G002,I201,I100,I101 --enable-extensions G argoverse
    mypy --ignore-missing --strict argoverse


### PR DESCRIPTION
Remove the Jupyter temporary checkpoints for the stereo notebook.
Add the `.ipynb_checkpoints` folder to `.gitignore` to avoid the temporary Jupyter checkpoints being pushed in.
Replace `pip3 install numba` from `tox.ini` to `setup.py` to make numba a required dependency.