### PR TITLE
account for rounding in point cloud projection

### DIFF
--- a/argoverse/utils/calibration.py
+++ b/argoverse/utils/calibration.py
@@ -376,8 +376,8 @@ def determine_valid_cam_coords(uv: np.ndarray, uv_cam: np.ndarray, camera_config
     Returns:
        Numpy array of shape (N,) with dtype bool
     """
-    x_valid = np.logical_and(0 <= uv[:, 0], uv[:, 0] < camera_config.img_width)
-    y_valid = np.logical_and(0 <= uv[:, 1], uv[:, 1] < camera_config.img_height)
+    x_valid = np.logical_and(0 <= np.round(uv[:, 0]), np.round(uv[:, 0]) < camera_config.img_width)
+    y_valid = np.logical_and(0 <= np.round(uv[:, 1]), np.round(uv[:, 1]) < camera_config.img_height)
     z_valid = uv_cam[2, :] > 0
     valid_pts_bool = np.logical_and(np.logical_and(x_valid, y_valid), z_valid)
     return valid_pts_bool


### PR DESCRIPTION
The current code still considers a uv point that rounds up to the img width/height as valid. This causes errors when you try to run draw_ground_pts_in_image() in the ground_visualization.py. 

