### PR TITLE
allow free Numpy version in requirements list for resolver conflict resolution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "matplotlib",
         "motmetrics==1.1.3",
         "numba",
-        "numpy==1.19",
+        "numpy",
         "omegaconf==2.1.0",
         "opencv-python>=4.1.0.25",
         "pandas>=0.23.1",


### PR DESCRIPTION
Pinning to Numpy 1.19 creates many dependency conflicts.