### PR TITLE
Unpin `numpy`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "matplotlib",
         "motmetrics==1.1.3",
         "numba",
-        "numpy==1.19",
+        "numpy",
         "omegaconf==2.1.0",
         "opencv-python>=4.1.0.25",
         "pandas>=0.23.1",


### PR DESCRIPTION
Unpin `numpy` to avoid compatibility issues with `scipy`. 