### PR TITLE
generate_sequence_video.py: Add one condition to filter out files

### DIFF
--- a/argoverse/visualization/generate_sequence_videos.py
+++ b/argoverse/visualization/generate_sequence_videos.py
@@ -93,7 +93,8 @@ def main(arguments: List[str]) -> int:
 
         from moviepy.editor import ImageSequenceClip
 
-        img_idx = sorted([int(x.split(".")[0]) for x in os.listdir(seq_out_dir)])
+        #img_idx = sorted([int(x.split(".")[0]) for x in os.listdir(seq_out_dir)])
+        img_idx = sorted([int(x.split(".")[0]) for x in os.listdir(seq_out_dir) if x.split(".")[0].isdigit()])
         list_video = [f"{seq_out_dir}/{x}.png" for x in img_idx]
         clip = ImageSequenceClip(list_video, fps=10)
         video_path = os.path.join(args.output_dir, f"{seq_name.split('.')[0]}.mp4")


### PR DESCRIPTION
Question: There are one or more files in the video_output directory, and their names are not pure numbers or the file names start with a dot (`.`), e.g., hidden files or non-image files.

Resolution: - Modified script to handle filenames more robustly. For example, add some conditions to filter out files that don't match the naming rules. 

```
img_idx = sorted([int(x.split(".")[0]) for x in os.listdir(seq_out_dir) if x.split(".")[0].isdigit()])
```
